### PR TITLE
Add X-Plausible-IP header to the event request

### DIFF
--- a/event.go
+++ b/event.go
@@ -156,6 +156,7 @@ func (pef *PlausibleEventFeeder) reportEventToPlausible(ctx context.Context, cli
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("User-Agent", event.userAgent)
 	request.Header.Set("X-Forwarded-For", event.remoteIP.String())
+	request.Header.Set("X-Plausible-IP", event.remoteIP.String())
 
 	// Send to plausible.
 	resp, err := client.Do(request)


### PR DESCRIPTION
After https://github.com/plausible/analytics/pull/3689 we can use the specialised header to pass the client IP and not be afraid of overrides "X-Forwarded-For" by Cloudflare or similar proxies. 